### PR TITLE
release: Release cloud_events 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### v0.2.0 / 2020-08-24
+
+* Feature: Test feat 1
+* Feature: Test feat 2
+* Fixed: Test fix 1
+* Fixed: Test fix 2
+* Documentation: Test docs 1
+
 ### v0.1.1 / 2020-07-20
 
 * Updated a few documentation links. No functional changes.

--- a/lib/cloud_events/version.rb
+++ b/lib/cloud_events/version.rb
@@ -5,5 +5,5 @@ module CloudEvents
   # Version of the Ruby CloudEvents SDK
   # @return [String]
   #
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
## Release cloud_events 0.2.0

This pull request prepares a new release of cloud_events. To confirm the release, merge, ensuring the "release: pending" label is set.

An initial changelog has been constructed from [conventional commit](https://conventionalcommits.org) messages, and is provided in this pull request (and is also quoted below). Feel free to edit the changelog and/or release version before merging. Note that the changelog header format must remain the same, and must match the release version, or the release will not succeed.

To abort the release, close this pull request without merging.

---

### v0.2.0 / 2020-08-24

* Feature: Test feat 1
* Feature: Test feat 2
* Fixed: Test fix 1
* Fixed: Test fix 2
* Documentation: Test docs 1
